### PR TITLE
Prevent IAE when accessing GraalVM classes

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/poi/runtime/graal/POIFeature.java
+++ b/runtime/src/main/java/io/quarkiverse/poi/runtime/graal/POIFeature.java
@@ -1,18 +1,16 @@
 package io.quarkiverse.poi.runtime.graal;
 
-import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
-import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 
 public class POIFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        final RuntimeClassInitializationSupport runtimeInit = ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
         final String reason = "Quarkus run time init for Apache POI";
-        runtimeInit.initializeAtRunTime("org.apache.poi.hssf.util", reason);
-        runtimeInit.initializeAtRunTime("org.apache.poi.ss.format", reason);
-        runtimeInit.initializeAtRunTime("org.apache.poi.util.RandomSingleton", reason);
-        runtimeInit.initializeAtRunTime("org.apache.poi.ss.util.SheetUtil", reason);
+        RuntimeClassInitialization.initializeAtRunTime("org.apache.poi.hssf.util", reason);
+        RuntimeClassInitialization.initializeAtRunTime("org.apache.poi.ss.format", reason);
+        RuntimeClassInitialization.initializeAtRunTime("org.apache.poi.util.RandomSingleton", reason);
+        RuntimeClassInitialization.initializeAtRunTime("org.apache.poi.ss.util.SheetUtil", reason);
     }
 
     @Override


### PR DESCRIPTION
This prevents the following error when building to native using the following environment: 
```
native-image 21 2023-09-19
OpenJDK Runtime Environment Mandrel-23.1.0.0-Final (build 21+35-LTS)
OpenJDK 64-Bit Server VM Mandrel-23.1.0.0-Final (build 21+35-LTS, mixed mode)
```

Error:

```
Caused by: java.lang.IllegalAccessError: class io.quarkiverse.poi.runtime.graal.POIFeature (in unnamed module @0x127e70c5) cannot access class org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport (in module org.graalvm.nativeimage) because module org.graalvm.nativeimage does not export org.graalvm.nativeimage.impl to unnamed module @0x127e70c5
```