### PR TITLE
Use `nativeimage` instead of `graal-sdk`

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
-      <artifactId>graal-sdk</artifactId>
+      <artifactId>nativeimage</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
`graal-sdk` depends on the polyglot classes, which are unused